### PR TITLE
Expose various AminoExtract functions for direct python calls

### DIFF
--- a/AminoExtract/__init__.py
+++ b/AminoExtract/__init__.py
@@ -8,5 +8,5 @@ __version__ = "0.2.1"
 with contextlib.suppress(ImportError):
     from AminoExtract.__main__ import get_feature_name_attribute, main
     from AminoExtract.filter import filter_gff
-    from AminoExtract.reader import GffDataFrame, read_gff
+    from AminoExtract.reader import GffDataFrame, read_gff, read_fasta
     from AminoExtract.sequences import extract_aminoacids

--- a/AminoExtract/__init__.py
+++ b/AminoExtract/__init__.py
@@ -7,3 +7,6 @@ __version__ = "0.2.1"
 # This may occur when this file is imported in setup.py as dependencies are not yet installed
 with contextlib.suppress(ImportError):
     from AminoExtract.__main__ import get_feature_name_attribute, main
+    from AminoExtract.filter import filter_gff
+    from AminoExtract.reader import GffDataFrame, read_gff
+    from AminoExtract.sequences import extract_aminoacids

--- a/AminoExtract/__main__.py
+++ b/AminoExtract/__main__.py
@@ -9,7 +9,7 @@ import sys
 from AminoExtract.args import validate_args
 from AminoExtract.filter import empty_dataframe, filter_gff, filter_sequences
 from AminoExtract.reader import read_fasta, read_gff
-from AminoExtract.sequences import Extract_AminoAcids
+from AminoExtract.sequences import extract_aminoacids
 from AminoExtract.writer import write_aa_file
 
 
@@ -59,7 +59,7 @@ def main() -> None:
     sys.exit(1) if empty_dataframe(GFF_Obj.df, args.feature_type) else None
     SeqRecords = filter_sequences(GFF_Obj, fasta_records)
 
-    AA_dict = Extract_AminoAcids(
+    AA_dict = extract_aminoacids(
         GFFobj=GFF_Obj, SeqRecords=SeqRecords, keep_gaps=args.keep_gaps, verbose=True
     )
 

--- a/AminoExtract/args.py
+++ b/AminoExtract/args.py
@@ -62,8 +62,8 @@ def check_file_ext(
 
     """
     if fname is not None and os.path.isfile(fname):
-        file_exts = "".join(pathlib.Path(fname).suffixes)
-        if choices is not None and file_exts not in choices:
+        ext = "".join(pathlib.Path(fname).suffixes)
+        if not any(ext.endswith(c) for c in choices):
             log.error(
                 f"{fname} does not have a valid {ftype} file extension.\nPlease use any of the following extensions: [bold]{' '.join(choices)}[/bold]"
             )

--- a/AminoExtract/reader.py
+++ b/AminoExtract/reader.py
@@ -99,28 +99,29 @@ class GffDataFrame(object):
         return self.df
 
     def _split_attributes_column(self) -> pd.DataFrame:
-        """Takes a dataframe with a column called "attributes" that contains a string of attributes, and it
-        returns a dataframe with the attributes split into separate columns
+            """
+            Takes a dataframe with a column called "attributes" that contains a string of attributes, and it
+            returns a dataframe with the attributes split into separate columns.
 
-        Parameters
-        ----------
-        df : pd.DataFrame
+            Parameters
+            ----------
+            None
 
-        Returns
-        -------
-            A dataframe with the attributes column split into individual columns.
-
-        """
-        self.df["attributes"] = self.df["attributes"].apply(_attr_string_to_dict)
-        columns = self.df.columns.tolist()
-        # remove key-value pair from the dictionary in the attributes column if the key is already a column
-        self.df["attributes"] = self.df["attributes"].apply(
-            lambda attr: {k: v for k, v in attr.items() if k not in columns}
-        )
-        self.df = self.df.join(pd.DataFrame(self.df["attributes"].to_dict()).T).drop(
-            "attributes", axis=1
-        )
-        return self.df
+            Returns
+            -------
+            pd.DataFrame
+                A dataframe with the attributes column split into individual columns.
+            """
+            self.df["attributes"] = self.df["attributes"].apply(_attr_string_to_dict)
+            columns = self.df.columns.tolist()
+            # remove key-value pair from the dictionary in the attributes column if the key is already a column
+            self.df["attributes"] = self.df["attributes"].apply(
+                lambda attr: {k: v for k, v in attr.items() if k not in columns}
+            )
+            self.df = self.df.join(pd.DataFrame(self.df["attributes"].to_dict()).T).drop(
+                "attributes", axis=1
+            )
+            return self.df
 
     def _read_header(self):
         self.header = ""
@@ -142,7 +143,8 @@ class GffDataFrame(object):
 
 
 def _attr_string_to_dict(string: str) -> dict:
-    """Takes a string like "a=1;b=2;c=3" and returns a dictionary like {"a": "1", "b": "2", "c": "3"}
+    """
+    Takes a string like "a=1;b=2;c=3" and returns a dictionary like {"a": "1", "b": "2", "c": "3"}
 
     Parameters
     ----------
@@ -151,14 +153,15 @@ def _attr_string_to_dict(string: str) -> dict:
 
     Returns
     -------
+    dict
         A dictionary with the key being the attribute name and the value being the attribute value.
-
     """
     return dict([x.split("=") for x in string.split(";") if "=" in x])
 
 
 def _is_gzipped(infile: str) -> bool:
-    """Returns `True` if the file is gzipped, and `False` otherwise
+    """
+    Returns `True` if the file is gzipped, and `False` otherwise.
 
     Parameters
     ----------
@@ -167,14 +170,16 @@ def _is_gzipped(infile: str) -> bool:
 
     Returns
     -------
-        The mime type of the file.
+    bool
+        `True` if the file is gzipped, and `False` otherwise.
 
     """
     return magic.from_file(infile, mime=True) == "application/gzip"
 
 
 def readable_file_type(infile: str) -> bool:
-    """Returns `True` if the file is a plain text file or a gzip file, and `False` otherwise
+    """
+    Returns `True` if the file is a plain text file or a gzip file, and `False` otherwise.
 
     Parameters
     ----------
@@ -183,8 +188,8 @@ def readable_file_type(infile: str) -> bool:
 
     Returns
     -------
-        A boolean value.
-
+    bool
+        A boolean value indicating whether the file is a plain text file or a gzip file.
     """
     return bool(
         magic.from_file(infile, mime=True) == "text/plain" or "application/gzip"
@@ -213,17 +218,20 @@ def read_gff(file: str, verbose: bool = False, split_attributes: bool = False) -
 
 
 def read_fasta(file: str, verbose: bool = False) -> list:
-    """Reads a FASTA file and returns a list of SeqRecord objects
+    """
+    Reads a FASTA file and returns a list of SeqRecord objects
 
     Parameters
     ----------
     file : str
-        str
+        The path to the FASTA file to be read.
+    verbose : bool, optional
+        If True, log information about the file being parsed.
 
     Returns
     -------
-        A list of SeqRecord objects
-
+    list
+        A list of SeqRecord objects representing the sequences in the input file.
     """
     log.info(f"Parsing FASTA input file: '[green]{file}[/green]'") if verbose else None
     return list(SeqIO.parse(file, "fasta"))

--- a/AminoExtract/reader.py
+++ b/AminoExtract/reader.py
@@ -73,6 +73,7 @@ class GffDataFrame(object):
                 "attributes",
             ],
             compression="gzip",
+            keep_default_na=False,
         )
         self.df = self._split_attributes_column()
         return self.df
@@ -93,6 +94,7 @@ class GffDataFrame(object):
                 "phase",
                 "attributes",
             ],
+            keep_default_na=False,
         )
         self.df = self._split_attributes_column()
         return self.df
@@ -190,7 +192,7 @@ def readable_file_type(infile: str) -> bool:
     )
 
 
-def read_gff(file: str, verbose: bool = True) -> GffDataFrame:
+def read_gff(file: str, verbose: bool = False) -> GffDataFrame:
     """Reads a GFF file and returns a GFFdataframe object
 
     Parameters

--- a/AminoExtract/reader.py
+++ b/AminoExtract/reader.py
@@ -11,7 +11,7 @@ from AminoExtract.functions import log
 # It reads in a GFF file and stores its contents as a GFFdataframe object
 class GffDataFrame(object):
     def __init__(
-        self, logger=log, inputfile: str | None = None, verbose: bool = False
+        self, logger=log, inputfile: str | None = None, verbose: bool = False, split_attributes: bool = False
     ) -> None:
         None if inputfile else sys.exit("Inputfile is not provided")
         if readable_file_type(inputfile):
@@ -23,6 +23,7 @@ class GffDataFrame(object):
             ) if verbose else None
             self._read()
             self._read_header()
+            self.df = self._split_attributes_column() if split_attributes else self.df
         else:
             self.log = log
             self.verbose = verbose
@@ -75,7 +76,6 @@ class GffDataFrame(object):
             compression="gzip",
             keep_default_na=False,
         )
-        self.df = self._split_attributes_column()
         return self.df
 
     def _read_gff_uncompressed(self) -> pd.DataFrame:
@@ -96,7 +96,6 @@ class GffDataFrame(object):
             ],
             keep_default_na=False,
         )
-        self.df = self._split_attributes_column()
         return self.df
 
     def _split_attributes_column(self) -> pd.DataFrame:
@@ -192,22 +191,25 @@ def readable_file_type(infile: str) -> bool:
     )
 
 
-def read_gff(file: str, verbose: bool = False) -> GffDataFrame:
-    """Reads a GFF file and returns a GFFdataframe object
+def read_gff(file: str, verbose: bool = False, split_attributes: bool = False) -> GffDataFrame:
+    """
+    Reads a GFF file and returns a GffDataFrame object.
 
     Parameters
     ----------
     file : str
-        str
+        The path to the GFF file to be read.
     verbose : bool, optional
         If True, print out the number of lines read in.
+    split_attributes : bool, optional
+        If True, split the attributes column into separate columns.
 
     Returns
     -------
-        A GffDataFrame object.
-
+    GffDataFrame
+        A GffDataFrame object containing the data from the GFF file.
     """
-    return GffDataFrame(inputfile=file, verbose=verbose)
+    return GffDataFrame(inputfile=file, verbose=verbose, split_attributes=split_attributes)
 
 
 def read_fasta(file: str, verbose: bool = False) -> list:

--- a/AminoExtract/sequences.py
+++ b/AminoExtract/sequences.py
@@ -1,7 +1,7 @@
 from Bio.Seq import Seq
 
 from AminoExtract.functions import log
-from AminoExtract.reader import GffDataFrame
+from AminoExtract.reader import GffDataFrame, _split_attributes_column
 
 
 def Reverse_complement(seq: str) -> Seq:
@@ -59,8 +59,12 @@ def extract_aminoacids(
     # create an empty dictionary
     AA_dict = {record.id: {} for record in SeqRecords}
 
+    tempdf = GFFobj.df.copy()
+    if "attributes" in tempdf.columns:
+        tempdf = _split_attributes_column(df=tempdf)
+
     # iterate through the dataframe
-    for row in GFFobj.df.itertuples():
+    for row in tempdf.itertuples():
         try:
             name = row.Name
         except AttributeError:

--- a/AminoExtract/sequences.py
+++ b/AminoExtract/sequences.py
@@ -21,7 +21,7 @@ def Reverse_complement(seq: str) -> Seq:
     return seq_obj.reverse_complement()  # type: ignore as BioPythons seq object is weird with typehints
 
 
-def Extract_AminoAcids(
+def extract_aminoacids(
     GFFobj: GffDataFrame,
     SeqRecords: list,
     keep_gaps: bool = False,

--- a/AminoExtract/writer.py
+++ b/AminoExtract/writer.py
@@ -31,6 +31,7 @@ def write_aa_file(
 
     log.info(f"{'='*20} Writing output(s) {'='*20}")
     if outtype == 0:
+        # this should probably be changed so a user can specify the fasta header per record instead of assuming {name}.{feature}
         with open(output, "w") as out:
             for SeqID, features in AA_dict.items():
                 for feature, aa in features.items():
@@ -46,5 +47,5 @@ def write_aa_file(
                 log.info(
                     f"Writing '[cyan]{SeqID} - {feature}[/cyan]' to file \"[green]{output / f'{name}_{feature}.faa'}[/green]\""
                 )
-                with open(output / f"{name}_{feature}.faa", "w") as out:
+                with open(output / f"{name}_{feature}.faa", "a") as out:
                     out.write(f">{SeqID}.{feature}\n{aa}\n")

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 
 # AminoExtract
 
-AminoExtract is a tool that extracts amino acid sequences from nucleotide sequences based on a GFF input file.
+AminoExtract is a CLI tool and library to work with GFF files, and extract amino acid sequences from nucleotide sequences based on a GFF input file.
+
 
 AminoExtract is able to filter the genomic features in the input files to make sure your output makes sense and to write the resulting amino acid sequences to either a single file or to individual files for every feature, depending on your inputs as a user.
+
+Additionally, AminoExtract allows you to use GFF data in python by making it accessible in a pandas dataframe structure.
 
 ## Why this tool?
 Because sometimes you just want a dedicated tool to do a mundane task. And sometimes it's just simply necessary to, for example, ensure reproducibility, portability or to facilitate long-term maintainability of larger projects.
@@ -20,9 +23,24 @@ Dependencies such as Pandas, Biopython and python-magic are installed during the
 
 ## Installation instructions
 
-Installation through conda and pip will be made available soon.
+AminoExtract can be instsalled easily with [conda](https://anaconda.org/bioconda/aminoextract) or [pip](https://pypi.org/project/AminoExtract/).  
+Installation through conda is recommended.
 
-1. Download the latest version of AminoExtract by cloning this repository and navigate to the newly created direcotry.  
+### Installation with conda
+
+```bash
+conda install -c bioconda -c conda-forge aminoextract
+```
+
+### Installation with pip
+
+```bash
+pip install AminoExtract
+```
+
+### Installation from source
+
+1. Download the latest version of AminoExtract by cloning this repository and navigate to the newly created directory.  
 Copy and paste the code-snippet below in order to do so.  
 ```
 git clone https://github.com/RIVM-bioinformatics/AminoExtract.git && cd AminoExtract/

--- a/env.yml
+++ b/env.yml
@@ -7,7 +7,7 @@ channels:
   - defaults
 dependencies:
   - python>=3.10
-  - biopython=1.79
-  - rich=12
+  - biopython>=1.79
+  - rich==13.*
   - pandas
-  - python-magic
+  - python-magic==0.4.*

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">=3.10",
     packages=find_packages(),
-    install_requires=["biopython", "pandas", "rich", "python-magic"],
+    install_requires=["biopython>=1.79", "pandas", "rich==13.*", "python-magic==0.4.*"],
     entry_points={
         "console_scripts": [
             "aminoextract = AminoExtract.__main__:main",


### PR DESCRIPTION
This is especially useful for handling gff data / datastructures in more programmatic ways

Also included in this pull is some general maintenance such as:
* clearing up various docstrings
* fix a bug when an input file has more than one dot
* change file writing to append mode so records don't get overwritten
* correct handling of "NA" text values in (for example) the SeqID --> this is now no longer interpreted as a Nonevalue
* update installation instructions